### PR TITLE
Add super-slow option for solar system sim

### DIFF
--- a/js/model/SolarSystemCommonModel.ts
+++ b/js/model/SolarSystemCommonModel.ts
@@ -82,7 +82,8 @@ export default abstract class SolarSystemCommonModel {
   public readonly timeSpeedMap = new Map<TimeSpeed, number>( [
     [ TimeSpeed.FAST, 7 / 4 ],
     [ TimeSpeed.NORMAL, 1 ],
-    [ TimeSpeed.SLOW, 1 / 4 ]
+    [ TimeSpeed.SLOW, 1 / 4 ],
+    [ TimeSpeed.SUPER_SLOW, 1 / 16 ]
   ] );
 
   public readonly timeProperty: NumberProperty;

--- a/js/view/SolarSystemCommonTimeControlNode.ts
+++ b/js/view/SolarSystemCommonTimeControlNode.ts
@@ -69,7 +69,7 @@ export default class SolarSystemCommonTimeControlNode extends TimeControlNode {
 
       // TimeControlNodeOptions
       timeSpeedProperty: model.timeSpeedProperty,
-      timeSpeeds: [ TimeSpeed.FAST, TimeSpeed.NORMAL, TimeSpeed.SLOW ],
+      timeSpeeds: [ TimeSpeed.FAST, TimeSpeed.NORMAL, TimeSpeed.SLOW, TimeSpeed.SUPER_SLOW ],
       scale: 0.9,
       playPauseStepButtonOptions: {
         playPauseStepXSpacing: PUSH_BUTTON_SPACING,


### PR DESCRIPTION
Adds a super-slow option that slows down the solar system simulation by 16x(instead of 4x like the regular slow mode does).

This PR was written from popular request from my classmates, who said that they wanted a way to slow down the simulation even more for increased precision.

Linked PRs:
1. https://github.com/phetsims/scenery-phet/pull/937